### PR TITLE
Fix tests and add a benchmark

### DIFF
--- a/op_test.go
+++ b/op_test.go
@@ -1,0 +1,23 @@
+package loris
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func BenchmarkParseCommand(b *testing.B) {
+	commands := make([]io.Reader, b.N)
+	for i := 0; i < b.N; i++ {
+		s := strconv.Itoa(i)
+		c := fmt.Sprintf("*3\r\n$3\r\nset\r\n$3\r\nkey\r\n$%d\r\n%s\r\n", len(s), s)
+		commands[i] = strings.NewReader(c)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		ParseCommand(commands[i])
+	}
+}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,8 +13,8 @@ var TV1 = Val([]byte{0, 1, 2, 3})
 var TV2 = Val([]byte{4, 5, 6, 7, 8, 9, 10})
 
 func TestMutexMapStore(t *testing.T) {
-	mms := NewMutexMapStore()
-	t.Run("MutexMapStore", func(t *testing.T) { testAll(t, mms) })
+	mms := NewMutexMap()
+	t.Run("MutexMap", func(t *testing.T) { testAll(t, mms) })
 }
 
 func testAll(t *testing.T, s Store) {
@@ -36,7 +37,9 @@ func testBasic(t *testing.T, s Store) {
 	v, err = s.Get(TK2)
 	a.NoError(err)
 	a.Equal(TV2, v)
-	a.Equal([]Key{TK1, TK2}, s.Keys())
+	keys := s.Keys()
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	a.Equal([]Key{TK1, TK2}, keys)
 	a.Equal(2, s.Len())
 
 	a.NoError(s.Del(TK1))


### PR DESCRIPTION
Add a benchmark for parsing a set command, and fix a problem with key ordering (keys from maps are random in go)