### PR TITLE
Change to use scanner

### DIFF
--- a/cmd/loris/main.go
+++ b/cmd/loris/main.go
@@ -51,7 +51,7 @@ func main() {
 		log.Fatalf("Error constructing store: %s", err)
 	}
 	log.Printf("Using store %s", o.storeName)
-	gr := loris.NewWithStore(store, o.debug)
+	l := loris.NewWithStore(store, o.debug)
 	if o.cpuProfile != "" {
 		f, err := os.Create(o.cpuProfile)
 		if err != nil {
@@ -63,6 +63,6 @@ func main() {
 		}
 		defer pprof.StopCPUProfile()
 	}
-	err = gr.ListenAndServe(fmt.Sprintf(":%d", o.port))
+	err = l.ListenAndServe(fmt.Sprintf(":%d", o.port))
 	log.Printf("Server exited: %s", err)
 }

--- a/loris.go
+++ b/loris.go
@@ -36,15 +36,15 @@ func (s *Server) ListenAndServe(hostport string) error {
 	if err != nil {
 		return fmt.Errorf("Failed to listen: %s", err)
 	}
-	conn_id := 0
+	connID := 0
 	go func() {
 		for {
 			conn, err := ln.Accept()
 			if err != nil {
 				log.Printf("Failed to accept: %s", err)
 			}
-			go s.handleConnection(context.WithValue(s.ctx, "id", conn_id), conn)
-			conn_id += 1
+			go s.handleConnection(context.WithValue(s.ctx, "id", connID), conn)
+			connID ++
 		}
 	}()
 	<-s.ctx.Done()

--- a/op.go
+++ b/op.go
@@ -25,7 +25,7 @@ func OpDel(s store.Store, k store.Key, v store.Val) (store.Val, error) {
 }
 
 func ParseCommand(r io.Reader) (ServerOp, error) {
-	respCmd, err := resp.Parse(bufio.NewReader(r))
+	respCmd, err := resp.Parse(bufio.NewScanner(r))
 	if err != nil {
 		return nil, err
 	}

--- a/resp/resp_test.go
+++ b/resp/resp_test.go
@@ -20,7 +20,7 @@ func TestBasic(t *testing.T) {
 
 	for _, tc := range testCases {
 		r := strings.NewReader(tc.s)
-		t, err := Parse(bufio.NewReader(r))
+		t, err := Parse(bufio.NewScanner(r))
 		a.NoError(err, "Can parse [%s]", tc.s)
 		a.Equal(tc.t, t)
 


### PR DESCRIPTION
Looking at the benchmark output for loirs, we find that we are doing a large number of allocations on each loop:

```
C:\Users\jordanc\vscode\loris>go test -benchmem -bench .
goos: windows
goarch: amd64
pkg: github.com/jbert/loris
BenchmarkParseCommand-4           500000              3871 ns/op            4775 B/op         43 allocs/op
PASS
ok      github.com/jbert/loris  2.554s
```

Changing to use Scanner simplifies things as we read one line at a time (though this might be a problem for long keys / values), and we get direct access to a non-copying byte buffer. We still do a similar size of allocations, but much fewer overall allocations:

```
C:\Users\jordanc\vscode\loris>go test -benchmem -bench .
goos: windows
goarch: amd64
pkg: github.com/jbert/loris
BenchmarkParseCommand-4          1000000              2421 ns/op            4384 B/op          8 allocs/op
PASS
ok      github.com/jbert/loris  3.248s
```

This also suggests that a state machine that forward parses into a buffer and then extracts slices from it (which scanner mostly does) could be even faster.